### PR TITLE
Switching inherited container to bitnami docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
-FROM odoo:13.0
+FROM bitnami/odoo:13.0.20200310-debian-10-r18
 
 USER root
 COPY ./add-ons /mnt/extra-addons
 COPY ./themes /mnt/extra-addons
 COPY ./scripts/entrypoint.sh /
 COPY ./odoo.conf /etc/odoo/
-RUN chown odoo /etc/odoo/odoo.conf
-RUN chmod 777 /entrypoint.sh
+#RUN chown odoo /etc/odoo/odoo.conf
+#RUN chmod 777 /entrypoint.sh
 
-USER odoo
-ENTRYPOINT [ "/entrypoint.sh" ]
-CMD ["odoo"]
+#USER odoo


### PR DESCRIPTION
There appear to be issues with how the stock docker container behaves in Kubernetes. Switching the inheritance to the bitnami container seems to correct these issues.