### PR TITLE
Remove some default groups

### DIFF
--- a/add-ons/hr_modifier/__manifest__.py
+++ b/add-ons/hr_modifier/__manifest__.py
@@ -11,6 +11,7 @@
         'base', 'hr', 'hr_skills'
     ],
     'data': [
+        'security/base_groups.xml',
         'security/hr_security.xml',
         'security/ir.model.access.csv',
         'views/hr_job_views.xml',

--- a/add-ons/hr_modifier/security/base_groups.xml
+++ b/add-ons/hr_modifier/security/base_groups.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="default_user" model="res.users">
+            <field name="groups_id" eval="[(3,ref('base.group_partner_manager'))]"/>
+        </record>
+    </data>
+</odoo>

--- a/add-ons/hr_modifier/security/base_groups.xml
+++ b/add-ons/hr_modifier/security/base_groups.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
-        <record id="default_user" model="res.users">
+        <record id="base.default_user" model="res.users">
             <field name="groups_id" eval="[(3,ref('base.group_partner_manager'))]"/>
         </record>
     </data>

--- a/add-ons/hr_modifier/security/hr_security.xml
+++ b/add-ons/hr_modifier/security/hr_security.xml
@@ -1,28 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
+
       <record id="make_invisible" model="res.groups">
           <field name="name">Invisible</field>
       </record>
+
       <record id="group_hr_senior_management" model="res.groups">
           <field name="name">Employees / Senior Management</field>
           <field name="category_id" ref="base.module_category_human_resources_employees"/>
           <field name="implied_ids" eval="[(4, ref('hr.group_hr_user'))]"/>
       </record>
 
-        <record id="hr_senior_management_rule" model="ir.rule">
-          <field name="name">Senior Management</field>
-          <field name="model_id" ref="hr.model_hr_employee"/>
-          <field name="groups" eval="[(4, ref('group_hr_senior_management'))]"/>
-          <field name="perm_read" eval="1"/>
-          <field name="perm_write" eval="1"/>
-          <field name="perm_create" eval="1"/>
-          <field name="perm_unlink" eval="1"/>
-          <field name="domain_force">[('id', 'child_of', [employee.id for employee in user.employee_ids])]</field>
-        </record>
+      <record id="hr_senior_management_rule" model="ir.rule">
+        <field name="name">Senior Management</field>
+        <field name="model_id" ref="hr.model_hr_employee"/>
+        <field name="groups" eval="[(4, ref('group_hr_senior_management'))]"/>
+        <field name="perm_read" eval="1"/>
+        <field name="perm_write" eval="1"/>
+        <field name="perm_create" eval="1"/>
+        <field name="perm_unlink" eval="1"/>
+        <field name="domain_force">[('id', 'child_of', [employee.id for employee in user.employee_ids])]</field>
+      </record>
 
       <record id="base.default_user" model="res.users">
           <field name="groups_id" eval="[(3,ref('hr.group_hr_manager')), (3,ref('hr.group_hr_user'))]"/>
       </record>
+
     </data>
 </odoo>

--- a/add-ons/hr_modifier/security/hr_security.xml
+++ b/add-ons/hr_modifier/security/hr_security.xml
@@ -1,23 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <record id="make_invisible" model="res.groups">
-        <field name="name">Invisible</field>
-    </record>
-    <record id="group_hr_senior_management" model="res.groups">
-        <field name="name">Employees / Senior Management</field>
-        <field name="category_id" ref="base.module_category_human_resources_employees"/>
-        <field name="implied_ids" eval="[(4, ref('hr.group_hr_user'))]"/>
-    </record>
     <data>
-      <record id="hr_senior_management_rule" model="ir.rule">
-        <field name="name">Senior Management</field>
-        <field name="model_id" ref="hr.model_hr_employee"/>
-        <field name="groups" eval="[(4, ref('group_hr_senior_management'))]"/>
-        <field name="perm_read" eval="1"/>
-        <field name="perm_write" eval="1"/>
-        <field name="perm_create" eval="1"/>
-        <field name="perm_unlink" eval="1"/>
-        <field name="domain_force">[('id', 'child_of', [employee.id for employee in user.employee_ids])]</field>
+      <record id="make_invisible" model="res.groups">
+          <field name="name">Invisible</field>
+      </record>
+      <record id="group_hr_senior_management" model="res.groups">
+          <field name="name">Employees / Senior Management</field>
+          <field name="category_id" ref="base.module_category_human_resources_employees"/>
+          <field name="implied_ids" eval="[(4, ref('hr.group_hr_user'))]"/>
+      </record>
+
+        <record id="hr_senior_management_rule" model="ir.rule">
+          <field name="name">Senior Management</field>
+          <field name="model_id" ref="hr.model_hr_employee"/>
+          <field name="groups" eval="[(4, ref('group_hr_senior_management'))]"/>
+          <field name="perm_read" eval="1"/>
+          <field name="perm_write" eval="1"/>
+          <field name="perm_create" eval="1"/>
+          <field name="perm_unlink" eval="1"/>
+          <field name="domain_force">[('id', 'child_of', [employee.id for employee in user.employee_ids])]</field>
+        </record>
+
+      <record id="base.default_user" model="res.users">
+          <field name="groups_id" eval="[(3,ref('hr.group_hr_manager')), (3,ref('hr.group_hr_user'))]"/>
       </record>
     </data>
 </odoo>


### PR DESCRIPTION
Remove 3 default groups upon user creation:

- Contact Creation
- Employee Administrator
- Employee Officer

Wasn't able to remove 2 base groups: **Access Private Addresses** and **Technical Features**.
Tried with (3,ref('base.group_private_addresses')) and (3,ref('base.group_no_one')) but didn't work.

But they don't seem to affect our use case for now. Private addresses are only related to private address type of Partner object (automatically created when we create an user, but that we don't use). And Technical Features doesn't seem to allow extra rights to users in practice.