### PR TITLE
Hiding the print badge button

### DIFF
--- a/add-ons/hr_modifier/views/hr_employee_views.xml
+++ b/add-ons/hr_modifier/views/hr_employee_views.xml
@@ -167,5 +167,16 @@
             <field name="active" eval="False" />
         </record>
 
+        <report
+            id="hr.hr_employee_print_badge"
+            string="Print Badge"
+            model="hr.employee"
+            report_type="qweb-pdf"
+            name="hr.print_employee_badge"
+            file="hr.print_employee_badge"
+            print_report_name="'Print Badge - %s' % (object.name).replace('/', '')"
+            menu="False"
+        />
+
     </data>
 </odoo>


### PR DESCRIPTION
There is currently a problem with hiding the button. On a fresh install of the module, the button remains. If you upgrade the module, the button does disappear. I thought that maybe it was the order in which the xml was rendered - perhaps the record we're trying to alter wasn't in the database by the time the xml here is rendered, but I couldn't get it working.

Either this PR gets merged and another ticket is opened to handle that issue, or the problem is resolved in this branch before it's merged.