### PR TITLE
Don't remove Contact Creation right from default group

### DIFF
--- a/add-ons/hr_modifier/__manifest__.py
+++ b/add-ons/hr_modifier/__manifest__.py
@@ -11,7 +11,6 @@
         'base', 'hr', 'hr_skills'
     ],
     'data': [
-        'security/base_groups.xml',
         'security/hr_security.xml',
         'security/ir.model.access.csv',
         'views/hr_job_views.xml',

--- a/add-ons/hr_modifier/security/base_groups.xml
+++ b/add-ons/hr_modifier/security/base_groups.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo>
-    <data>
-        <record id="base.default_user" model="res.users">
-            <field name="groups_id" eval="[(3,ref('base.group_partner_manager'))]"/>
-        </record>
-    </data>
-</odoo>


### PR DESCRIPTION
We need it so that the user can edit his email address for example.