### PR TITLE
added sub skills to menu

### DIFF
--- a/add-ons/hr_modifier/__manifest__.py
+++ b/add-ons/hr_modifier/__manifest__.py
@@ -21,6 +21,7 @@
         'views/hr_department_views.xml',
         'views/hr_employee_classification_views.xml',
         'views/hr_employee_region_views.xml',
+        'views/hr_skills.xml',
         'views/hr_views.xml',
         'views/mail_channel_views.xml'
     ],

--- a/add-ons/hr_modifier/views/hr_skills.xml
+++ b/add-ons/hr_modifier/views/hr_skills.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+<data>
+    <record id="hr_sub_skill_action" model="ir.actions.act_window">
+        <field name="name">Sub Skills</field>
+        <field name="res_model">hr.skill</field>
+        <field name="view_ids" eval="[(5, 0, 0), (0, 0, {'view_mode': 'tree', 'view_id': ref('hr_skills.employee_skill_view_tree')})]"/>
+    </record>
+</data>
+</odoo>

--- a/add-ons/hr_modifier/views/hr_views.xml
+++ b/add-ons/hr_modifier/views/hr_views.xml
@@ -58,17 +58,10 @@
     sequence="2"/>
 
     <menuitem
-    id="hr_skill_main_menu"
-    name="Skills"
-    parent="hr.menu_human_resources_configuration_employee"
-    sequence="3"
-    groups="hr.group_hr_manager,group_hr_senior_management"/>
-
-    <menuitem
     id="hr_skills.hr_skill_type_menu"
-    name="Types"
+    name="Skills"
     action="hr_skills.hr_skill_type_action"
-    parent="hr_skill_main_menu"
+    parent="hr.menu_human_resources_configuration"
     sequence="3"
     groups="hr.group_hr_manager,group_hr_senior_management"/>
 
@@ -76,9 +69,9 @@
     id="hr_skill_sub_skill_menu"
     name="Sub Skills"
     action="hr_sub_skill_action"
-    parent="hr_skill_main_menu"
+    parent="hr.menu_human_resources_configuration"
     sequence="3"
-    groups="hr.group_hr_manager,group_hr_senior_management"/>
+    groups="hr.group_hr_manager"/>
 
     <menuitem
     id = "hr.menu_human_resources_configuration_regions"

--- a/add-ons/hr_modifier/views/hr_views.xml
+++ b/add-ons/hr_modifier/views/hr_views.xml
@@ -58,10 +58,25 @@
     sequence="2"/>
 
     <menuitem
-    id="hr_skills.hr_skill_type_menu"
+    id="hr_skill_main_menu"
     name="Skills"
-    action="hr_skills.hr_skill_type_action"
     parent="hr.menu_human_resources_configuration_employee"
+    sequence="3"
+    groups="hr.group_hr_manager,group_hr_senior_management"/>
+
+    <menuitem
+    id="hr_skills.hr_skill_type_menu"
+    name="Types"
+    action="hr_skills.hr_skill_type_action"
+    parent="hr_skill_main_menu"
+    sequence="3"
+    groups="hr.group_hr_manager,group_hr_senior_management"/>
+
+    <menuitem
+    id="hr_skill_sub_skill_menu"
+    name="Sub Skills"
+    action="hr_sub_skill_action"
+    parent="hr_skill_main_menu"
     sequence="3"
     groups="hr.group_hr_manager,group_hr_senior_management"/>
 


### PR DESCRIPTION
Was unable to assign External ID to sub skills through UI import.  So I have created a small view to allow import of sub skills first then can import parent skills that reference the sub-skills via external ID. This way, import through UI is possible 
![Screen Shot 2020-04-16 at 12 26 11 PM](https://user-images.githubusercontent.com/26819992/79481421-77a4a400-7fdd-11ea-950f-81e8b88ec24d.png)
