### PR TITLE
remove departments validation

### DIFF
--- a/add-ons/hr_modifier/models/hr_department.py
+++ b/add-ons/hr_modifier/models/hr_department.py
@@ -17,14 +17,3 @@ class Department(models.Model):
     @api.onchange("x_coordinators_ids")
     def _onchange_coordinator(self):
         [ self.env[i].clear_caches() for i in self.env ]
-    
-    # Validation
-
-    # allow upper case, lower case, hyphens
-    @api.constrains("name")
-    def _check_name_allowed_characters(self):
-        for record in self:
-            if record.name:
-                res = re.search(r"[^\w\d\s\-.,'&/()@]", record.name)
-                if res:
-                    raise ValidationError("The team name contains an invalid character: " + res.group(0))


### PR DESCRIPTION
Removing validation on department name as it's causing errors with the importer. Furthermore we have confirmed that Odoo escapes SQL so there is no concern from a security perspective.