### PR TITLE
Fix security for reporter user type

### DIFF
--- a/add-ons/hr_modifier/security/ir.model.access.csv
+++ b/add-ons/hr_modifier/security/ir.model.access.csv
@@ -6,6 +6,7 @@ access_hr_coordinator,hr.employee hr_coordinator,hr.model_hr_employee,group_hr_c
 access_hr_coordinator_public,hr.employee.public hr_coordinator,hr.model_hr_employee_public,group_hr_coordinator,0,0,0,0
 access_hr_management_public_employees,hr.employee.public hr_management,hr.model_hr_employee_public,hr.group_hr_manager,1,1,0,0
 access_hr_employee_region,hr.region,model_hr_region,hr.group_hr_user,1,1,1,1
+access_hr_reporter_region,hr.region,model_hr_region,group_hr_reporter,1,0,0,0
 access_hr_employee_branch,hr.branch,model_hr_branch,hr.group_hr_user,1,1,1,1
 access_hr_reporter,hr.employee hr_reporter,hr.model_hr_employee,group_hr_reporter,1,0,0,0
 access_hr_reporter_public,hr.employee.public hr_reporter,hr.model_hr_employee_public,group_hr_reporter,0,0,0,0


### PR DESCRIPTION
The regions section has been added to the security csv to let reporter users view the pages as read only.