### PR TITLE
login attempts

### DIFF
--- a/add-ons/odoo_web_login/templates/webclient_templates.xml
+++ b/add-ons/odoo_web_login/templates/webclient_templates.xml
@@ -58,4 +58,8 @@
 		</xpath>
 	</template>
 
+	<data noupdate="0">
+		<function model="ir.config_parameter" name="set_param" eval="('base.login_cooldown_after', '3')" />
+		<function model="ir.config_parameter" name="set_param" eval="('base.login_cooldown_duration', '30')" />
+	</data>
 </odoo>

--- a/add-ons/odoo_web_login/templates/webclient_templates.xml
+++ b/add-ons/odoo_web_login/templates/webclient_templates.xml
@@ -60,6 +60,6 @@
 
 	<data noupdate="0">
 		<function model="ir.config_parameter" name="set_param" eval="('base.login_cooldown_after', '3')" />
-		<function model="ir.config_parameter" name="set_param" eval="('base.login_cooldown_duration', '30')" />
+		<function model="ir.config_parameter" name="set_param" eval="('base.login_cooldown_duration', '1800')" />
 	</data>
 </odoo>


### PR DESCRIPTION
resolves gcdevops/HRWhiteListing#163

Updates 2 configuration parameters, base.login_cooldown_after and base.login_cooldown_duration. base.login_cooldown_after is the number of attempts before locking the account and base.login_cooldown_duration is the duration in seconds. Values are set to 3 attempts and a 30 minute lockout.

There is no parameter for number of attempts in 15 minutes, like what the issue is asking for and adding that will take a significantly longer time to complete.