### PR TITLE
Employee in AD field

### DIFF
--- a/add-ons/hr_modifier/models/hr_employee_base.py
+++ b/add-ons/hr_modifier/models/hr_employee_base.py
@@ -79,6 +79,8 @@ class HrEmployeeBase(models.AbstractModel):
     )
 
     x_employee_access_gov_office = fields.Boolean("Access to a government office", groups="hr.group_hr_user,hr.group_hr_reporter")
+
+    x_employee_in_ad = fields.Boolean("Employee in AD", groups="hr.group_hr_user,hr.group_hr_reporter")
     
     x_employee_device_type = fields.Selection(
         [

--- a/add-ons/hr_modifier/models/hr_employee_public.py
+++ b/add-ons/hr_modifier/models/hr_employee_public.py
@@ -33,6 +33,8 @@ class HrEmployeePublic(models.Model):
 
     region_id = fields.Many2one(readonly=True)
 
+    branch_id = fields.Many2one(readonly=True)
+
     x_employee_remote_access_network = fields.Boolean(readonly=True)
 
     x_employee_remote_access_tool = fields.Selection(readonly = True)

--- a/add-ons/hr_modifier/views/hr_employee_public_views.xml
+++ b/add-ons/hr_modifier/views/hr_employee_public_views.xml
@@ -53,6 +53,9 @@
                                 <p style="font-size:1.2em"> 
                                     Team: <field name="department_id" context="{'hierarchical_naming': False}"/>
                                 </p>
+                                <p style="font-size:1.2em"> 
+                                    BRM Branch: <field name="branch_id"/>
+                                </p>
                             </div>
                             <field name="company_id" string="Company" invisible="1"/>
                         <notebook>

--- a/add-ons/hr_modifier/views/hr_employee_views.xml
+++ b/add-ons/hr_modifier/views/hr_employee_views.xml
@@ -95,8 +95,13 @@
                         <notebook>
                             <page name="public" string="Management Information">
                                 <group>
-                                    <field name="x_employee_job_code"/>
-                                    <field name="x_employee_work_criticality"/>
+                                    <group>
+                                        <field name="x_employee_job_code"/>
+                                        <field name="x_employee_work_criticality"/>
+                                    </group>
+                                    <group>
+                                        <field name="x_employee_in_ad" readonly="1"/>
+                                    </group>
                                 </group>
                                 <field name="employee_skill_ids"/>
                             </page>


### PR DESCRIPTION
Checkbox to specify whether or not an employee is present in AD data. This is necessary for the continuous AD import 

resolves https://github.com/gcdevops/HRWhiteListing/issues/321****